### PR TITLE
Add macos CI runner on github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,10 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     permissions:
       checks: write
       pull-requests: write
@@ -19,10 +22,16 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install system packages
+      - name: Install system packages (Linux)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y libsndfile1
+      - name: Install system packages (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew update
+          brew install libsndfile
       - name: Install Python deps
         run: |
           python -m pip install --upgrade pip
@@ -36,7 +45,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: test-reports
+          name: ${{ runner.os }}-test-reports
           path: reports
       - name: Publish unit test results
         if: always()


### PR DESCRIPTION
Add macOS to the CI workflow to expand test coverage.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8782d7b-dac0-4d33-bf8f-d2d4dbc0a756">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8782d7b-dac0-4d33-bf8f-d2d4dbc0a756">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

