### PR TITLE
Show decoded count in ci test report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
       contents: read
       checks: write
       pull-requests: write
+      issues: write
     steps:
       - name: Checkout repository (with submodules)
         uses: actions/checkout@v4
@@ -116,5 +117,46 @@ jobs:
           files: reports/junit.xml
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: 'Unit Test Results'
+
+      - name: Comment short regression decodes on PR
+        if: always() && github.event_name == 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          src_file=""
+          if [ -f reports/pytest.out ]; then src_file=reports/pytest.out; elif [ -f reports/pytest.log ]; then src_file=reports/pytest.log; fi
+          title="Short Regression Decodes"
+          body="Short Regression Decodes:\n"
+          if [ -n "$src_file" ]; then
+            line=$(grep -F "SHORT TOTAL:" "$src_file" | tail -n 1 || true)
+            if [ -n "$line" ]; then
+              pe=$(printf "%s" "$line" | sed -n 's/.*pos_expected=\([0-9][0-9]*\).*/\1/p')
+              pm=$(printf "%s" "$line" | sed -n 's/.*pos_matched=\([0-9][0-9]*\).*/\1/p')
+              if [ -n "$pe" ] && [ -n "$pm" ]; then
+                pct=$(awk -v pm="$pm" -v pe="$pe" 'BEGIN { if (pe>0) printf "%.1f", (pm/pe*100); }')
+                if [ -n "$pct" ]; then
+                  body+="Matched: ${pm} / ${pe} (${pct}%)\n"
+                else
+                  body+="Matched: ${pm} / ${pe}\n"
+                fi
+              else
+                body+="Totals line found, but could not parse numbers.\n"
+              fi
+            else
+              body+="Short regression totals not found in output (test may have been skipped).\n"
+            fi
+          else
+            body+="Pytest output/log not found.\n"
+          fi
+
+          # Find existing comment by this workflow to update (idempotent)
+          pr_number=${{ github.event.number }}
+          repo=${{ github.repository }}
+          existing_id=$(gh api repos/$repo/issues/$pr_number/comments --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("'"$title"'")) | .id' | head -n1 || true)
+          if [ -n "$existing_id" ]; then
+            gh api repos/$repo/issues/comments/$existing_id -X PATCH -f body="$body"
+          else
+            gh api repos/$repo/issues/$pr_number/comments -X POST -f body="$body"
+          fi
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         run: |
           mkdir -p reports
           set -o pipefail
+          export SHORT_SUMMARY_PATH=reports/short_summary.txt
           pytest -vv -ra --durations=0 --maxfail=1 --color=yes --capture=tee-sys --junitxml=reports/junit.xml --log-file=reports/pytest.log --log-file-level=INFO 2>&1 | tee reports/pytest.out
 
       - name: Summarize short regression decodes
@@ -135,47 +136,52 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           check_name: 'Unit Test Results'
 
-      - name: Comment short regression decodes on PR
+      - name: Update Unit Test Results comment with short regression
         if: always() && github.event_name == 'pull_request' && runner.os == 'Linux'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          src_file=""
-          if [ -f reports/pytest.out ]; then src_file=reports/pytest.out; elif [ -f reports/pytest.log ]; then src_file=reports/pytest.log; fi
-          title="Short Regression Decodes"
-          body="Short Regression Decodes:"
-          wavs="unknown"
-          if [ -f reports/short_wav_count.txt ]; then wavs=$(cat reports/short_wav_count.txt); fi
-          if [ -n "$src_file" ]; then
-            line=$(grep -F "SHORT TOTAL:" "$src_file" | tail -n 1 || true)
-            if [ -n "$line" ]; then
+          # Prefer machine-readable summary from the test
+          if [ -f reports/short_summary.txt ]; then
+            pe=$(sed -n 's/.*pos_expected=\([0-9][0-9]*\).*/\1/p' reports/short_summary.txt)
+            pm=$(sed -n 's/.*pos_matched=\([0-9][0-9]*\).*/\1/p' reports/short_summary.txt)
+          else
+            src_file=""
+            if [ -f reports/pytest.out ]; then src_file=reports/pytest.out; elif [ -f reports/pytest.log ]; then src_file=reports/pytest.log; fi
+            if [ -n "$src_file" ]; then
+              line=$(grep -F "SHORT TOTAL:" "$src_file" | tail -n 1 || true)
               pe=$(printf "%s" "$line" | sed -n 's/.*pos_expected=\([0-9][0-9]*\).*/\1/p')
               pm=$(printf "%s" "$line" | sed -n 's/.*pos_matched=\([0-9][0-9]*\).*/\1/p')
-              if [ -n "$pe" ] && [ -n "$pm" ]; then
-                pct=$(awk -v pm="$pm" -v pe="$pe" 'BEGIN { if (pe>0) printf "%.1f", (pm/pe*100); }')
-                if [ -n "$pct" ]; then
-                  body="$body"$'\n'"Matched: ${pm} / ${pe} (${pct}%)"
-                else
-                  body="$body"$'\n'"Matched: ${pm} / ${pe}"
-                fi
-              else
-                body="$body"$'\n'"Totals line found, but could not parse numbers."
-              fi
-            else
-              body="$body"$'\n'"Short regression totals not found in output (test may have been skipped). WAV files detected: $wavs"
             fi
-          else
-            body="$body"$'\n'"Pytest output/log not found. WAV files detected: $wavs"
           fi
 
-          # Find existing comment by this workflow to update (idempotent)
+          if [ -n "$pe" ] && [ -n "$pm" ]; then
+            pct=$(awk -v pm="$pm" -v pe="$pe" 'BEGIN { if (pe>0) printf "%.1f", (pm/pe*100); }')
+            if [ -n "$pct" ]; then
+              line="Short Regression Decodes: Matched: ${pm} / ${pe} (${pct}%)"
+            else
+              line="Short Regression Decodes: Matched: ${pm} / ${pe}"
+            fi
+          else
+            wavs="unknown"
+            if [ -f reports/short_wav_count.txt ]; then wavs=$(cat reports/short_wav_count.txt); fi
+            line="Short Regression Decodes: not available (WAV files detected: $wavs)"
+          fi
+
           pr_number=${{ github.event.number }}
           repo=${{ github.repository }}
-          existing_id=$(gh api repos/$repo/issues/$pr_number/comments --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("'"$title"'")) | .id' | head -n1 || true)
-          if [ -n "$existing_id" ]; then
-            gh api repos/$repo/issues/comments/$existing_id -X PATCH -f body="$body"
-          else
-            gh api repos/$repo/issues/$pr_number/comments -X POST -f body="$body"
+          # Find the Unit Test Results comment from the unit test results action
+          utr_id=$(gh api repos/$repo/issues/$pr_number/comments --jq '.[] | select(.user.login == "github-actions[bot]") | select(.body | contains("Unit Test Results")) | .id' | head -n1 || true)
+          if [ -z "$utr_id" ]; then
+            echo "No Unit Test Results comment found; skipping append."
+            exit 0
           fi
+
+          body=$(gh api repos/$repo/issues/comments/$utr_id --jq .body)
+          new_block="<!-- SHORT-REG-START -->\n${line}\n<!-- SHORT-REG-END -->"
+          # Remove existing block if present, then append the new block at the end
+          cleaned=$(printf "%s" "$body" | sed -e '/<!-- SHORT-REG-START -->/,/<!-- SHORT-REG-END -->/d')
+          updated_body="$cleaned"$'\n\n'"$new_block"
+          gh api repos/$repo/issues/comments/$utr_id -X PATCH -f body="$updated_body"
 
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,12 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+          lfs: true
+
+      - name: Fetch Git LFS for submodules
+        run: |
+          git lfs install
+          git submodule foreach --recursive 'git lfs install && git lfs pull && git lfs checkout || true'
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -69,6 +75,15 @@ jobs:
           make -C external/ft8_lib clean
           make -C external/ft8_lib decode_ft8 CFLAGS="-D_DARWIN_C_SOURCE -D_POSIX_C_SOURCE=200809L" LDFLAGS="" LDLIBS="-lm"
 
+      - name: Ensure test WAV dataset present
+        run: |
+          mkdir -p reports
+          git -C external/ft8_lib lfs pull || true
+          git -C external/ft8_lib lfs checkout || true
+          count=$(find external/ft8_lib/test/wav -type f -name '*.wav' 2>/dev/null | wc -l | tr -d ' ')
+          echo "$count" > reports/short_wav_count.txt
+          echo "Short dataset wav files: $count"
+
       - name: Run tests
         run: |
           mkdir -p reports
@@ -81,6 +96,8 @@ jobs:
           echo "### Short Regression Decodes" >> "$GITHUB_STEP_SUMMARY"
           src_file=""
           if [ -f reports/pytest.out ]; then src_file=reports/pytest.out; elif [ -f reports/pytest.log ]; then src_file=reports/pytest.log; fi
+          wavs="unknown"
+          if [ -f reports/short_wav_count.txt ]; then wavs=$(cat reports/short_wav_count.txt); fi
           if [ -n "$src_file" ]; then
             line=$(grep -F "SHORT TOTAL:" "$src_file" | tail -n 1 || true)
             if [ -n "$line" ]; then
@@ -97,10 +114,10 @@ jobs:
                 echo "Totals line found, but could not parse numbers." >> "$GITHUB_STEP_SUMMARY"
               fi
             else
-              echo "Short regression totals not found in output (test may have been skipped)." >> "$GITHUB_STEP_SUMMARY"
+              echo "Short regression totals not found in output (test may have been skipped). WAV files detected: $wavs" >> "$GITHUB_STEP_SUMMARY"
             fi
           else
-            echo "Pytest output/log not found." >> "$GITHUB_STEP_SUMMARY"
+            echo "Pytest output/log not found. WAV files detected: $wavs" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Upload test reports
@@ -119,14 +136,16 @@ jobs:
           check_name: 'Unit Test Results'
 
       - name: Comment short regression decodes on PR
-        if: always() && github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request' && runner.os == 'Linux'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           src_file=""
           if [ -f reports/pytest.out ]; then src_file=reports/pytest.out; elif [ -f reports/pytest.log ]; then src_file=reports/pytest.log; fi
           title="Short Regression Decodes"
-          body="Short Regression Decodes:\n"
+          body="Short Regression Decodes:"
+          wavs="unknown"
+          if [ -f reports/short_wav_count.txt ]; then wavs=$(cat reports/short_wav_count.txt); fi
           if [ -n "$src_file" ]; then
             line=$(grep -F "SHORT TOTAL:" "$src_file" | tail -n 1 || true)
             if [ -n "$line" ]; then
@@ -135,18 +154,18 @@ jobs:
               if [ -n "$pe" ] && [ -n "$pm" ]; then
                 pct=$(awk -v pm="$pm" -v pe="$pe" 'BEGIN { if (pe>0) printf "%.1f", (pm/pe*100); }')
                 if [ -n "$pct" ]; then
-                  body+="Matched: ${pm} / ${pe} (${pct}%)\n"
+                  body="$body"$'\n'"Matched: ${pm} / ${pe} (${pct}%)"
                 else
-                  body+="Matched: ${pm} / ${pe}\n"
+                  body="$body"$'\n'"Matched: ${pm} / ${pe}"
                 fi
               else
-                body+="Totals line found, but could not parse numbers.\n"
+                body="$body"$'\n'"Totals line found, but could not parse numbers."
               fi
             else
-              body+="Short regression totals not found in output (test may have been skipped).\n"
+              body="$body"$'\n'"Short regression totals not found in output (test may have been skipped). WAV files detected: $wavs"
             fi
           else
-            body+="Pytest output/log not found.\n"
+            body="$body"$'\n'"Pytest output/log not found. WAV files detected: $wavs"
           fi
 
           # Find existing comment by this workflow to update (idempotent)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,36 @@ jobs:
       - name: Run tests
         run: |
           mkdir -p reports
-          pytest -vv -ra --durations=0 --maxfail=1 --color=yes --capture=tee-sys --junitxml=reports/junit.xml --log-file=reports/pytest.log --log-file-level=INFO
+          set -o pipefail
+          pytest -vv -ra --durations=0 --maxfail=1 --color=yes --capture=tee-sys --junitxml=reports/junit.xml --log-file=reports/pytest.log --log-file-level=INFO 2>&1 | tee reports/pytest.out
+
+      - name: Summarize short regression decodes
+        if: always()
+        run: |
+          echo "### Short Regression Decodes" >> "$GITHUB_STEP_SUMMARY"
+          src_file=""
+          if [ -f reports/pytest.out ]; then src_file=reports/pytest.out; elif [ -f reports/pytest.log ]; then src_file=reports/pytest.log; fi
+          if [ -n "$src_file" ]; then
+            line=$(grep -F "SHORT TOTAL:" "$src_file" | tail -n 1 || true)
+            if [ -n "$line" ]; then
+              pe=$(printf "%s" "$line" | sed -n 's/.*pos_expected=\([0-9][0-9]*\).*/\1/p')
+              pm=$(printf "%s" "$line" | sed -n 's/.*pos_matched=\([0-9][0-9]*\).*/\1/p')
+              if [ -n "$pe" ] && [ -n "$pm" ]; then
+                pct=$(awk -v pm="$pm" -v pe="$pe" 'BEGIN { if (pe>0) printf "%.1f", (pm/pe*100); }')
+                if [ -n "$pct" ]; then
+                  echo "Matched: ${pm} / ${pe} (${pct}%)" >> "$GITHUB_STEP_SUMMARY"
+                else
+                  echo "Matched: ${pm} / ${pe}" >> "$GITHUB_STEP_SUMMARY"
+                fi
+              else
+                echo "Totals line found, but could not parse numbers." >> "$GITHUB_STEP_SUMMARY"
+              fi
+            else
+              echo "Short regression totals not found in output (test may have been skipped)." >> "$GITHUB_STEP_SUMMARY"
+            fi
+          else
+            echo "Pytest output/log not found." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Upload test reports
         if: always()

--- a/tests/test_dataset_short_regression.py
+++ b/tests/test_dataset_short_regression.py
@@ -47,13 +47,16 @@ def _select_fixed_20_percent(wavs: list[Path], base: Path) -> list[Path]:
 def test_short_dataset_regression_20pct():
 	dataset = Path(__file__).resolve().parents[1] / "external" / "ft8_lib" / "test" / "wav"
 	if not dataset.exists():
+		print("SHORT TOTAL: pos_expected=0 pos_matched=0 (dataset-not-available)")
 		pytest.skip("dataset not available")
 	wavs = sorted(dataset.rglob("*.wav"))
 	if not wavs:
+		print("SHORT TOTAL: pos_expected=0 pos_matched=0 (no-wav-files)")
 		pytest.skip("no wav files")
 
 	sample = _select_fixed_20_percent(wavs, dataset)
 	if not sample:
+		print("SHORT TOTAL: pos_expected=0 pos_matched=0 (no-files-selected)")
 		pytest.skip("no files selected in 20% sampling")
 
 	total_pos_expected = 0


### PR DESCRIPTION
Add short regression decode summary to CI report to show matched/total counts.

---
<a href="https://cursor.com/background-agent?bcId=bc-43fedae7-704e-401c-962e-779d7f0dc262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43fedae7-704e-401c-962e-779d7f0dc262">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

