### PR TITLE
Fix LLR bit order for consistency

### DIFF
--- a/src/ft8gpt/decoder_e2e.py
+++ b/src/ft8gpt/decoder_e2e.py
@@ -41,7 +41,7 @@ def llrs_from_waterfall(wf_group: np.ndarray) -> np.ndarray:
 	# wf_group shape [num_symbols, 8]
 	llrs: List[float] = []
 	for s in range(wf_group.shape[0]):
-		l0, l1, l2 = extract_symbol_llrs(wf_group[s])
+		l2, l1, l0 = extract_symbol_llrs(wf_group[s])
 		# Encoder packs bits per symbol as (b2,b1,b0); order LLRs accordingly
 		llrs.extend([l2, l1, l0])
 	return np.array(llrs[: 174], dtype=np.float64)

--- a/src/ft8gpt/tones.py
+++ b/src/ft8gpt/tones.py
@@ -3,34 +3,46 @@ from __future__ import annotations
 from typing import Tuple
 import numpy as np
 from numpy.typing import NDArray
+import math
 
 from .constants import FSK_TONES, FT8_GRAY_MAP
 
 
 def extract_symbol_llrs(mag_bins: NDArray[np.float64]) -> Tuple[float, float, float]:
-    """Compute unnormalized LLRs for the 3 bits using max-log metric.
-    mag_bins: shape [8], magnitudes at tone bins in natural frequency order (0..7).
+    """Order-correct per-symbol LLRs using Gray group log-sum metrics.
+    Returns (l2, l1, l0) to match (b2, b1, b0) ordering.
+    mag_bins: shape [8], magnitudes/energies at tone bins in natural frequency order (0..7).
+    """
+    return extract_symbol_llrs_gray_lse(mag_bins)
 
-    We first remap to Gray-ordered indexing s_gray[j] = mag_bins[FT8_GRAY_MAP[j]],
-    such that index j corresponds to binary bits (b2,b1,b0) of the tone.
+
+def extract_symbol_llrs_gray_lse(mag_bins: NDArray[np.float64]) -> Tuple[float, float, float]:
+    """Compute per-symbol LLRs in bit order (l2,l1,l0) = (b2,b1,b0).
+
+    Steps:
+      1) Remap to Gray-ordered energies s[j] = mag_bins[FT8_GRAY_MAP[j]] with ±1 neighbor tolerance.
+      2) Compute LLRs via log-sum over Gray groups for each bit.
     """
     # Build Gray-ordered energies with tolerance for ±1-bin leakage
-    # Use a small penalty for neighbors to discourage large shifts while allowing slight offsets.
     s = np.empty(8, dtype=np.float64)
     for j in range(8):
-        fidx = FT8_GRAY_MAP[j]
-        candidates = [float(mag_bins[fidx])]
-        if fidx - 1 >= 0:
-            candidates.append(float(mag_bins[fidx - 1]))
-        if fidx + 1 < 8:
-            candidates.append(float(mag_bins[fidx + 1]))
-        s[j] = max(candidates)
+        tone = FT8_GRAY_MAP[j]
+        e0 = float(mag_bins[tone])
+        em = float(mag_bins[tone - 1]) if tone - 1 >= 0 else 0.0
+        ep = float(mag_bins[tone + 1]) if tone + 1 < 8 else 0.0
+        s[j] = max(e0, em, ep, 1e-20)
 
-    # LLRs following the simple max-of-groups scheme.
-    # Define LLR = logP(bit=0) - logP(bit=1) so that negative implies bit=1.
-    llr0 = max(s[0], s[1], s[2], s[3]) - max(s[4], s[5], s[6], s[7])
-    llr1 = max(s[0], s[1], s[4], s[5]) - max(s[2], s[3], s[6], s[7])
-    llr2 = max(s[0], s[2], s[4], s[6]) - max(s[1], s[3], s[5], s[7])
-    return llr0, llr1, llr2
+    # Bit grouping in Gray-index space j ∈ [0..7]
+    g2_0 = (0, 1, 2, 3); g2_1 = (4, 5, 6, 7)
+    g1_0 = (0, 1, 4, 5); g1_1 = (2, 3, 6, 7)
+    g0_0 = (0, 2, 4, 6); g0_1 = (1, 3, 5, 7)
+
+    def lse(idx: tuple[int, ...]) -> float:
+        return math.log(sum(s[k] for k in idx))
+
+    l2 = lse(g2_0) - lse(g2_1)
+    l1 = lse(g1_0) - lse(g1_1)
+    l0 = lse(g0_0) - lse(g0_1)
+    return l2, l1, l0
 
 

--- a/src/ft8gpt/tones.py
+++ b/src/ft8gpt/tones.py
@@ -30,7 +30,7 @@ def extract_symbol_llrs_gray_lse(mag_bins: NDArray[np.float64]) -> Tuple[float, 
         e0 = float(mag_bins[tone])
         em = float(mag_bins[tone - 1]) if tone - 1 >= 0 else 0.0
         ep = float(mag_bins[tone + 1]) if tone + 1 < 8 else 0.0
-        s[j] = max(e0, em, ep, 1e-20)
+        s[j] = max(e0, 0.5 * em, 0.5 * ep, 1e-20)
 
     # Bit grouping in Gray-index space j ∈ [0..7]
     g2_0 = (0, 1, 2, 3); g2_1 = (4, 5, 6, 7)

--- a/tests/test_dataset_short_regression.py
+++ b/tests/test_dataset_short_regression.py
@@ -98,7 +98,7 @@ def test_short_dataset_regression_20pct():
 	_write_short_summary(total_pos_expected, total_pos_matched)
 
 	# Ratchet for CI: require at least one exact-text, CRC-valid decode across the 20% sample
-	assert total_pos_matched >= 16, "expected at least sixteen matched decodes in 20% short regression"
+	assert total_pos_matched >= 18, "expected at least eighteen matched decodes in 20% short regression"
 
 	# Keep runtime guardrail similar to full test but this sample should be much faster
 	avg_runtime = (time.time() - t0) / max(1, len(sample))

--- a/tests/test_llr_ordering.py
+++ b/tests/test_llr_ordering.py
@@ -1,0 +1,32 @@
+import numpy as np
+
+from ft8gpt.constants import gray_to_bits
+from ft8gpt.tones import extract_symbol_llrs_gray_lse
+
+
+def test_llr_signs_match_gray_bits_peak_tones():
+	# For a strong single tone, LLR signs must match (b2,b1,b0)
+	for tone in range(8):
+		mag = np.zeros(8, dtype=np.float64)
+		mag[tone] = 10.0
+		l2, l1, l0 = extract_symbol_llrs_gray_lse(mag)
+		b2, b1, b0 = gray_to_bits(tone)
+		assert (l2 > 0) if b2 == 0 else (l2 < 0), f"bit2 sign mismatch for tone {tone}"
+		assert (l1 > 0) if b1 == 0 else (l1 < 0), f"bit1 sign mismatch for tone {tone}"
+		assert (l0 > 0) if b0 == 0 else (l0 < 0), f"bit0 sign mismatch for tone {tone}"
+
+
+def test_llr_robust_to_neighbor_leakage():
+	# With adjacent leakage, signs should remain consistent
+	for tone in range(8):
+		mag = np.zeros(8, dtype=np.float64)
+		mag[tone] = 10.0
+		if tone - 1 >= 0:
+			mag[tone - 1] = 2.0
+		if tone + 1 < 8:
+			mag[tone + 1] = 2.0
+		l2, l1, l0 = extract_symbol_llrs_gray_lse(mag)
+		b2, b1, b0 = gray_to_bits(tone)
+		assert (l2 > 0) if b2 == 0 else (l2 < 0), f"[nbr] bit2 sign mismatch for tone {tone}"
+		assert (l1 > 0) if b1 == 0 else (l1 < 0), f"[nbr] bit1 sign mismatch for tone {tone}"
+		assert (l0 > 0) if b0 == 0 else (l0 < 0), f"[nbr] bit0 sign mismatch for tone {tone}"


### PR DESCRIPTION
Unify LLR bit ordering to (l2,l1,l0) and improve calculation for consistent decoding.

The previous `extract_symbol_llrs` returned LLRs in (b0, b1, b2) order, which silently mismatched the (l2, l1, l0) order expected by `decoder_e2e` for LDPC input. This bit-order inversion scrambled soft information, significantly hindering decode rates. This PR corrects the LLR ordering and adds tests to prevent future regressions.

---
<a href="https://cursor.com/background-agent?bcId=bc-9e1aa84f-2d34-4c5d-8832-0dcb425a7563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9e1aa84f-2d34-4c5d-8832-0dcb425a7563">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

